### PR TITLE
use Markdown to escape `<>`

### DIFF
--- a/config.md
+++ b/config.md
@@ -106,7 +106,8 @@ println(py"res")
 #hideall
 using Markdown
 
-mdC_code = raw"""!#2"""
+mdC_code = Markdown.htmlesc(raw"""!#2""")
+
 mdfile = joinpath(dirname(@OUTPUT), "!#1.md")
 open(mdfile,"w") do f
     print(f, mdC_code)


### PR DESCRIPTION
escape C code to show `#include <stdio.h>` correctly.